### PR TITLE
More informative error handling if wrong channel

### DIFF
--- a/yasuf/yasuf.py
+++ b/yasuf/yasuf.py
@@ -88,7 +88,10 @@ class Yasuf:
 
         logger.info('Synchronizing time')
         response = self._send_message('Hello!')
-        self.start_time = float(response['ts'])
+        if not response['ok']:
+            raise Exception(response['error'])
+        else:
+            self.start_time = float(response['ts'])
 
     def _say_bye(self):
         """ Notify user that Yasuf is quiting. """


### PR DESCRIPTION
Current error message if an incorrect channel is entered is  
self.start_time = float(response['ts'])
KeyError: 'ts'

which is a little unhelpful.  This commit changes this to "Exception: channel_not_found".  Note that the exception contents will be whatever the error message content is, so this generalizes nicely to other errors too.
